### PR TITLE
Recount Week Numbers For Every Months

### DIFF
--- a/src/helpers/calendar.js
+++ b/src/helpers/calendar.js
@@ -23,8 +23,6 @@ export const CALENDAR_MONTHS = {
 	December: "Dec"
 }
 
-export const CALENDAR_WEEKS = 6;
-
 export const CALENDAR_MONTHS_30 = [4, 6, 9, 11];
 
 export const isDate = date => {
@@ -91,13 +89,17 @@ export const isSameMonth = (date1, date2) => {
     : false;
 }
 
+export const getWeeksToDisplay = (monthDays, monthFirstDay) => {
+	return Math.ceil((monthDays + monthFirstDay - 1) / 7);
+};
+
 export default (date = new Date) => {
 	const monthDays = getMonthDays(date);
 	const monthFirstDay = getMonthFirstDay(date);
   const [ year, month ] = getDateArray(date);
 
 	const daysFromPrevMonth = monthFirstDay - 1;
-	const daysFromNextMonth = (CALENDAR_WEEKS * 7) - (daysFromPrevMonth + monthDays);
+	const daysFromNextMonth = (getWeeksToDisplay(monthDays, monthFirstDay) * 7) - (daysFromPrevMonth + monthDays);
 
 	const { month: prevMonth, year: prevMonthYear } = getPreviousMonth(date);
 	const { month: nextMonth, year: nextMonthYear } = getNextMonth(date);


### PR DESCRIPTION
Instead of displaying always 6 weeks in the calendar, make it more flexible and the last week of each month will be the one where it ends, complete with days from the next month.

e.g. if a 28 days February starts on Sunday we display only 4 weeks, because the 28th will be Saturday, but if it has 29 days than there will be 5 weeks etc.
